### PR TITLE
Refactor schema handling

### DIFF
--- a/adaptor.js
+++ b/adaptor.js
@@ -188,7 +188,8 @@ function applySchema(generator, obj, subj, schema) {
         subj.itemsType = complexType;
         subj.itemsTypeSnake = Case.snake(complexType);
     }
-    subj.defaultValue = (schema && typeof schema.default !== 'undefined') ? schema.default : undefined;
+    subj.hasDefault = (schema && typeof schema.default !== 'undefined')
+    subj.defaultValue = subj.hasDefault ? schema.default : undefined;
     subj.description = obj.description||'';
 
     subj.vendorExtensions = specificationExtensions(obj);

--- a/adaptor.js
+++ b/adaptor.js
@@ -141,7 +141,9 @@ function applySchema(generator, obj, subj, schema) {
     subj.schema = schema;
     subj.jsonSchema = safeJson(schema,null,2);
     for (let p in schemaProperties) {
-        if (typeof schema[p] !== 'undefined') subj[p] = schema[p];
+        if (schemaProperties[p] in schema) {
+            subj[schemaProperties[p]] = schema[schemaProperties[p]];
+        }
     }
     subj.isEnum = !!schema.enum;
     subj.isBoolean = (schema.type === 'boolean');

--- a/adaptor.js
+++ b/adaptor.js
@@ -187,6 +187,7 @@ function applySchema(generator, obj, subj, schema) {
         let complexType = schema.items["x-oldref"].replace('#/components/schemas/','');
         subj.itemsType = complexType;
         subj.itemsTypeSnake = Case.snake(complexType);
+        subj.itemsComplexType = complexType;
     }
     subj.hasDefault = (schema && typeof schema.default !== 'undefined')
     subj.defaultValue = subj.hasDefault ? schema.default : undefined;

--- a/adaptor.js
+++ b/adaptor.js
@@ -185,9 +185,11 @@ function applySchema(generator, obj, subj, schema) {
     }
     if ((schema.type === 'array') && schema.items && schema.items["x-oldref"]) {
         let complexType = schema.items["x-oldref"].replace('#/components/schemas/','');
-        subj.itemsType = complexType;
-        subj.itemsTypeSnake = Case.snake(complexType);
         subj.itemsComplexType = complexType;
+    }
+    if ((schema.type === 'array') && schema.items && schema.items.type) {
+        subj.itemsType = schema.items.type;
+        subj.itemsTypeSnake = Case.snake(complexType);
     }
     subj.hasDefault = (schema && typeof schema.default !== 'undefined')
     subj.defaultValue = subj.hasDefault ? schema.default : undefined;

--- a/adaptor.js
+++ b/adaptor.js
@@ -170,7 +170,10 @@ function applySchema(generator, obj, subj, schema) {
     subj.isFloat = (subj.isNumber && schema.format === 'float');
     subj.isInt32 = (subj.isInteger && schema.format === 'int32');
     subj.isInt64 = (subj.isInteger && schema.format === 'int64');
-
+    subj.hasRange = (subj.isNumber && (
+        subj.minimum || subj.exclusiveMinimum
+        || subj.maximum  || subj.exclusiveMaximum)
+    );
     subj.isListContainer = schema.type === 'array';
     subj.isMapContainer = schema.type === 'subject';
     subj.isPrimitiveType = !subj.isListContainer && !subj.isMapContainer;

--- a/adaptor.js
+++ b/adaptor.js
@@ -183,6 +183,9 @@ function applySchema(generator, obj, subj, schema) {
     if ((schema.type === 'object') && schema.properties && schema.properties["x-oldref"]) {
         subj.complexType = schema.properties["x-oldref"].replace('#/components/schemas/','');
     }
+    if ((schema.type === 'object') && schema["x-oldref"]) {
+        subj.complexType = schema["x-oldref"].replace('#/components/schemas/','');
+    }
     if ((schema.type === 'array') && schema.items && schema.items["x-oldref"]) {
         let complexType = schema.items["x-oldref"].replace('#/components/schemas/','');
         subj.itemsComplexType = complexType;

--- a/adaptor.js
+++ b/adaptor.js
@@ -175,7 +175,6 @@ function applySchema(generator, obj, subj, schema) {
     subj.isMapContainer = schema.type === 'subject';
     subj.isPrimitiveType = !subj.isListContainer && !subj.isMapContainer;
     subj.isNotContainer = subj.isPrimitiveType;
-    if (subj.isEnum) subj.isNotContainer = false;
     subj.isContainer = !subj.isNotContainer;
 
     if ((schema.type === 'object') && schema.properties && schema.properties["x-oldref"]) {

--- a/adaptor.js
+++ b/adaptor.js
@@ -145,6 +145,12 @@ function applySchema(generator, obj, subj, schema) {
     }
     subj.isEnum = !!schema.enum;
     subj.isBoolean = (schema.type === 'boolean');
+    subj.isInteger = (schema.type === 'integer');
+    subj.isNumber = (schema.type === 'number' || schema.type === 'integer');
+    subj.isDouble = (subj.isNumber && schema.format === 'double');
+    subj.isFloat = (subj.isNumber && schema.format === 'float');
+    subj.isInt32 = (subj.isInteger && schema.format === 'int32');
+    subj.isInt64 = (subj.isInteger && schema.format === 'int64');
 
     subj.isListContainer = schema.type === 'array';
     subj.isMapContainer = schema.type === 'subject';

--- a/adaptor.js
+++ b/adaptor.js
@@ -162,6 +162,7 @@ function applySchema(generator, obj, subj, schema) {
     }
 
     subj.isString = (schema.type === 'string');
+    subj.hasPattern = (schema.pattern);
     subj.isBoolean = (schema.type === 'boolean');
     subj.isInteger = (schema.type === 'integer');
     subj.isNumber = (schema.type === 'number' || schema.type === 'integer');

--- a/adaptor.js
+++ b/adaptor.js
@@ -161,6 +161,7 @@ function applySchema(generator, obj, subj, schema) {
 
     }
 
+    subj.isString = (schema.type === 'string');
     subj.isBoolean = (schema.type === 'boolean');
     subj.isInteger = (schema.type === 'integer');
     subj.isNumber = (schema.type === 'number' || schema.type === 'integer');

--- a/docs/modelProperties.md
+++ b/docs/modelProperties.md
@@ -160,3 +160,4 @@
 |itemsComplexType|vars|OrderDetails|Stores the name of the model for array elements|
 |isString|vars/model|false|boolean - set to true when element is string|
 |hasPattern|vars/model|false|boolean - set to true when element is string and schema has pattern property|
+|hasRange|vars/model|false|boolean - set to true when element is one of number/integer/float and schema has minimum or maximum defined|

--- a/docs/modelProperties.md
+++ b/docs/modelProperties.md
@@ -158,3 +158,4 @@
 |isMapContainer|model|false|boolean - set to true when container is a map|
 |isArrayContainer|model|false|boolean - set to true when container is an array|
 |itemsComplexType|vars|OrderDetails|Stores the name of the model for array elements|
+|isString|vars/model|false|boolean - set to true when element is string|

--- a/docs/modelProperties.md
+++ b/docs/modelProperties.md
@@ -161,3 +161,4 @@
 |isString|vars/model|false|boolean - set to true when element is string|
 |hasPattern|vars/model|false|boolean - set to true when element is string and schema has pattern property|
 |hasRange|vars/model|false|boolean - set to true when element is one of number/integer/float and schema has minimum or maximum defined|
+|hasDefault|vars/model|false|boolean - set to true when schema has default property defined|

--- a/docs/modelProperties.md
+++ b/docs/modelProperties.md
@@ -159,3 +159,4 @@
 |isArrayContainer|model|false|boolean - set to true when container is an array|
 |itemsComplexType|vars|OrderDetails|Stores the name of the model for array elements|
 |isString|vars/model|false|boolean - set to true when element is string|
+|hasPattern|vars/model|false|boolean - set to true when element is string and schema has pattern property|

--- a/local.js
+++ b/local.js
@@ -33,18 +33,21 @@ function main(o, config, configName, callback) {
     let outputDir = config.outputDir || './out/';
     let verbose = config.defaults.verbose;
     config.defaults.configName = configName;
-
-    adaptor.transform(o, config.defaults, function(err, model) {
-        if (config.generator) {
-            model.generator = config.generator;
-        }
+    let generator = undefined;
+    if (config.generator) {
+        generator = config.generator;
+    }
+    adaptor.transform(generator, o, config.defaults, function(err, model) {
+        model["generator"] = generator;
         if (verbose) console.log('Processing lambdas '+Object.keys(lambdas));
         Object.keys(lambdas).forEach(key => model[key] = lambdas[key]);
 
-        if (config.generator && config.generator.lambdas) {
-            for (let lambda in config.generator.lambdas) {
+        if (verbose) console.log('Processing custom lambda '+generator.lambdas);
+
+        if (generator && generator.lambdas) {
+            for (let lambda in generator.lambdas) {
                 if (verbose) console.log('Processing lambda '+lambda);
-                model[lambda] = config.generator.lambdas[lambda];
+                model[lambda] = generator.lambdas[lambda];
             }
         }
         for (let p in config.partials) {


### PR DESCRIPTION
The handling of schema used to be inconsistent. For example `x-oldref` based values where added in one case and were missing in other cases. This simple refactoring moves the schema related updates of a subject into single place.
